### PR TITLE
Update bitvec dependency to  0.17.4

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -217,6 +217,16 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a993f74b4c99c1908d156b8d2e0fb6277736b0ecbd833982fd1241d39b2766a6"
 
 [[package]]
+name = "bitvec"
+version = "0.17.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "41262f11d771fd4a61aa3ce019fca363b4b6c282fca9da2a31186d3965a47a5c"
+dependencies = [
+ "either",
+ "radium",
+]
+
+[[package]]
 name = "blake2b_simd"
 version = "0.5.10"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -967,7 +977,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f509c5e67ca0605ee17dcd3f91ef41cadd685c75a298fb6261b781a5acb3f910"
 dependencies = [
  "arrayvec",
- "bitvec",
+ "bitvec 0.15.2",
  "byte-slice-cast",
  "serde",
 ]
@@ -1066,6 +1076,12 @@ checksum = "2bdc6c187c65bca4260c9011c9e3132efe4909da44726bad24cf7572ae338d7f"
 dependencies = [
  "proc-macro2 1.0.9",
 ]
+
+[[package]]
+name = "radium"
+version = "0.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "def50a86306165861203e7f84ecffbbdfdea79f0e51039b33de1e952358c47ac"
 
 [[package]]
 name = "rand"
@@ -1583,7 +1599,7 @@ version = "0.6.3"
 dependencies = [
  "base58",
  "bech32",
- "bitvec",
+ "bitvec 0.15.2",
  "digest 0.8.1",
  "failure",
  "hex 0.4.2",
@@ -1604,7 +1620,7 @@ name = "wagyu-ethereum"
 version = "0.6.3"
 dependencies = [
  "base58",
- "bitvec",
+ "bitvec 0.17.4",
  "ethereum-types",
  "hex 0.4.2",
  "hmac",

--- a/ethereum/Cargo.toml
+++ b/ethereum/Cargo.toml
@@ -20,7 +20,7 @@ edition = "2018"
 wagyu-model = { path = "../model", version = "0.6.3" }
 
 base58 = { version = "0.1" }
-bitvec = { version = "0.15.2" }
+bitvec = { version = "0.17.4" }
 ethereum-types = { version = "0.9.0" }
 hex = { version = "0.4.2" }
 hmac = { version = "0.7.0" }


### PR DESCRIPTION
`cargo update` is giving me an error about bitvec.

```
cargo update
    Updating crates.io index
error: failed to select a version for the requirement `bitvec = "^0.15.2"`
  candidate versions found which didn't match: 0.17.4
  location searched: crates.io index
required by package `wagyu-ethereum v0.6.2`
    ... which is depended on by `myproject v0.1.0 (/home/ski/code/myproject)`
```

Importantly, 0.17.2's [changelog](https://github.com/myrrlyn/bitvec/blob/master/CHANGELOG.md#0172) says "This crash is considered a severe bug, as it indicates memory unsafety. Users are strongly encouraged to update to 0.17.2 immediately."

I haven't tested this yet, but I will soon.