### PR TITLE
Removed unused libaries

### DIFF
--- a/bitcoin/src/extended_private_key.rs
+++ b/bitcoin/src/extended_private_key.rs
@@ -10,7 +10,6 @@ use wagyu_model::{
     AddressError, ChildIndex, DerivationPath, ExtendedPrivateKey, ExtendedPrivateKeyError, ExtendedPublicKey,
     PrivateKey,
 };
-use wagyu_model::no_std::*;
 
 use base58::{FromBase58, ToBase58};
 use core::{convert::TryFrom, fmt, fmt::Display, str::FromStr};
@@ -229,7 +228,6 @@ mod tests {
 
     use core::convert::TryInto;
     use hex;
-    use secp256k1::curve::Scalar;
 
     fn test_new<N: BitcoinNetwork>(
         expected_extended_private_key: &str,

--- a/bitcoin/src/extended_public_key.rs
+++ b/bitcoin/src/extended_public_key.rs
@@ -8,7 +8,6 @@ use wagyu_model::{
     crypto::{checksum, hash160},
     AddressError, ChildIndex, DerivationPath, ExtendedPrivateKey, ExtendedPublicKey, ExtendedPublicKeyError, PublicKey,
 };
-use wagyu_model::no_std::*;
 
 use base58::{FromBase58, ToBase58};
 use core::{convert::TryFrom, fmt, str::FromStr};

--- a/bitcoin/src/mnemonic.rs
+++ b/bitcoin/src/mnemonic.rs
@@ -7,7 +7,7 @@ use crate::private_key::BitcoinPrivateKey;
 use crate::public_key::BitcoinPublicKey;
 use crate::wordlist::BitcoinWordlist;
 use wagyu_model::{ExtendedPrivateKey, Mnemonic, MnemonicCount, MnemonicError, MnemonicExtended};
-use wagyu_model::no_std::{*, io::Read};
+use wagyu_model::no_std::*;
 
 use bitvec::prelude::*;
 use core::{fmt, marker::PhantomData, ops::Div, str, str::FromStr};

--- a/bitcoin/src/private_key.rs
+++ b/bitcoin/src/private_key.rs
@@ -3,7 +3,6 @@ use crate::format::BitcoinFormat;
 use crate::network::BitcoinNetwork;
 use crate::public_key::BitcoinPublicKey;
 use wagyu_model::{crypto::checksum, Address, AddressError, PrivateKey, PrivateKeyError, PublicKey};
-use wagyu_model::no_std::*;
 
 use base58::{FromBase58, ToBase58};
 use core::{fmt, fmt::Display, marker::PhantomData, str::FromStr};

--- a/bitcoin/src/public_key.rs
+++ b/bitcoin/src/public_key.rs
@@ -3,7 +3,6 @@ use crate::format::BitcoinFormat;
 use crate::network::BitcoinNetwork;
 use crate::private_key::BitcoinPrivateKey;
 use wagyu_model::{Address, AddressError, PublicKey, PublicKeyError};
-use wagyu_model::no_std::*;
 
 use core::{fmt, fmt::Display, marker::PhantomData, str::FromStr};
 use secp256k1;

--- a/ethereum/src/amount.rs
+++ b/ethereum/src/amount.rs
@@ -1,7 +1,6 @@
 use wagyu_model::{Amount, AmountError};
 
 use ethereum_types::U256;
-use serde::Serialize;
 use std::fmt;
 
 /// Represents the amount of Ethereum in wei


### PR DESCRIPTION
When compiling the source code, there are warnings of unused imports. 

warning: unused import: `serde::Serialize`
 --> ethereum\src\amount.rs:4:5
  |
4 | use serde::Serialize;
  |     ^^^^^^^^^^^^^^^^
  |
  = note: `#[warn(unused_imports)]` on by default

warning: unused import: `wagyu_model::no_std::*`
  --> bitcoin\src\extended_private_key.rs:13:5
   |
13 | use wagyu_model::no_std::*;
   |     ^^^^^^^^^^^^^^^^^^^^^^
   |
   = note: `#[warn(unused_imports)]` on by default

warning: unused import: `wagyu_model::no_std::*`
  --> bitcoin\src\extended_public_key.rs:11:5
   |
11 | use wagyu_model::no_std::*;
   |     ^^^^^^^^^^^^^^^^^^^^^^

warning: unused import: `io::Read`
  --> bitcoin\src\mnemonic.rs:10:30
   |
10 | use wagyu_model::no_std::{*, io::Read};
   |                              ^^^^^^^^

warning: unused import: `wagyu_model::no_std::*`
 --> bitcoin\src\private_key.rs:6:5
  |
6 | use wagyu_model::no_std::*;
  |     ^^^^^^^^^^^^^^^^^^^^^^

warning: unused import: `wagyu_model::no_std::*`
 --> bitcoin\src\public_key.rs:6:5
  |
6 | use wagyu_model::no_std::*;
  |     ^^^^^^^^^^^^^^^^^^^^^^

   Compiling wagyu v0.6.3 (C:\Users\septi\wagyu)
    Finished dev [unoptimized + debuginfo] target(s) in 38.91s